### PR TITLE
fix resources with colon in names

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -124,7 +124,7 @@ func processingArgs(set []string, output map[string][]string) (map[string][]stri
 
 	for _, k := range set {
 
-		switch p := strings.Split(k, ":"); {
+		switch p := strings.SplitN(k, ":", 1); {
 		case !strings.HasSuffix(p[0], "s"):
 			return nil, fmt.Errorf("resource %v must be plural", p[0])
 		case strings.Contains(p[1], ","):

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -124,7 +124,7 @@ func processingArgs(set []string, output map[string][]string) (map[string][]stri
 
 	for _, k := range set {
 
-		switch p := strings.SplitN(k, ":", 1); {
+		switch p := strings.SplitN(k, ":", 2); {
 		case !strings.HasSuffix(p[0], "s"):
 			return nil, fmt.Errorf("resource %v must be plural", p[0])
 		case strings.Contains(p[1], ","):


### PR DESCRIPTION
Resources with `:` in names should not be splitted